### PR TITLE
ログの処理実装

### DIFF
--- a/app/Logging/CustomizeFormatter.php
+++ b/app/Logging/CustomizeFormatter.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Logging;
+
+use Monolog\Formatter\LineFormatter;
+
+class CustomizeFormatter extends LineFormatter
+{
+    const LOG_FORMAT = "%datetime% [%channel%.%level_name%] %message%" . PHP_EOL;
+    const DATE_FORMAT = "Y-m-d H:i:s.v";
+
+    /**
+     * コンストラクタ
+     */
+    public function __construct()
+    {
+        parent::__construct(self::LOG_FORMAT, self::DATE_FORMAT, true, true);
+    }
+
+    /**
+     * ログをフォーマットする
+     * 
+     * @param array $record ログ定義情報配列
+     * @return string $output ログ内容
+     */
+    public function format(array $record): string
+    {
+        $output = parent::format($record);
+
+        return $output;
+    }
+}
+?>

--- a/app/Logging/LogTap.php
+++ b/app/Logging/LogTap.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Logging;
+
+use App\Logging\CustomizeFormatter;
+
+class LogTap
+{
+
+    /**
+     * 渡されたロガーインスタンスのカスタマイズ
+     *
+     * @param  \Illuminate\Log\Logger  $logger
+     * @return void
+     */
+    public function __invoke($logger)
+    {
+        $logFormatter = new CustomizeFormatter();
+
+        foreach($logger->getHandlers() as $handler) {
+            $handler->setFormatter($logFormatter);
+        }
+    }
+}
+
+?>

--- a/config/logging.php
+++ b/config/logging.php
@@ -37,7 +37,7 @@ return [
     'channels' => [
         'stack' => [
             'driver' => 'stack',
-            'channels' => ['single'],
+            'channels' => ['daily', 'errorlog'],
             'ignore_exceptions' => false,
         ],
 
@@ -52,6 +52,7 @@ return [
             'path' => storage_path('logs/laravel.log'),
             'level' => env('LOG_LEVEL', 'debug'),
             'days' => 14,
+            'tap' => [App\Logging\LogTap::class],
         ],
 
         'slack' => [
@@ -89,6 +90,9 @@ return [
         'errorlog' => [
             'driver' => 'errorlog',
             'level' => env('LOG_LEVEL', 'debug'),
+            'days' => 14,
+            'path' => storage_path('logs/error.log'),
+            'tap' => [App\Logging\LogTap::class],
         ],
 
         'null' => [


### PR DESCRIPTION
CustomLogFormatter
　ログの出力内容を処理する
LogTap
　logging.phpから参照される
　Laravelにログのフォーマットを反映する
logging
　laravel, errorの2つのログを出力するように設定
　日付ごとに出力するようにする

